### PR TITLE
fix repo links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 Once Helm is set up properly, add the repo as follows:
 
 ```console
-helm repo add unleash https://unleash.github.io/helm-charts
+helm repo add unleash https://docs.getunleash.ai/helm-charts
 ```
 
 You can then run `helm search repo unleash` to see the charts.

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -16,4 +16,4 @@ sources:
   - https://github.com/Unleash/unleash-docker
   - https://github.com/Unleash/helm-charts
 type: application
-version: 1.0.1
+version: 1.0.2

--- a/charts/unleash/README.md
+++ b/charts/unleash/README.md
@@ -13,7 +13,7 @@ This chart bootstraps a [Unleash](https://github.com/Unleash/unleash) deployment
 ## Get Repo Info
 
 ```console
-helm repo add unleash https://unleash.github.io/helm-charts
+helm repo add unleash https://docs.getunleash.ai/helm-charts
 helm repo update
 ```
 


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

fix the link to the helm repo in the readme.

needs to be merged after: https://github.com/Unleash/helm-charts/pull/7