### PR TITLE
[Unleash] Add annotations and loadBalancerSourceRanges in service template

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -16,4 +16,4 @@ sources:
   - https://github.com/Unleash/unleash-docker
   - https://github.com/Unleash/helm-charts
 type: application
-version: 1.0.3
+version: 1.0.4

--- a/charts/unleash/templates/service.yaml
+++ b/charts/unleash/templates/service.yaml
@@ -4,6 +4,12 @@ metadata:
   name: {{ include "unleash.fullname" . }}
   labels:
     {{- include "unleash.labels" . | nindent 4 }}
+{{- if .Values.service.annotations }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -13,3 +19,7 @@ spec:
       name: http
   selector:
     {{- include "unleash.selectorLabels" . | nindent 4 }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -207,6 +207,13 @@ secrets: {}
 service:
   type: ClusterIP
   port: 4242
+  annotations: {}
+  ## Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## Example:
+  ## loadBalancerSourceRanges:
+  ## - 10.10.10.0/24
+  loadBalancerSourceRanges: []
 
 tolerations: []
 


### PR DESCRIPTION
### Problem:
- It is not possible to create the service type "LoadBalancer" with annotations and loadBalancerSourceRanges

### Proposal:
- Add in template options to create service with annotations and loadBalancerSourceRanges

### What was changed
- Add options in service template
- Add new options in valeus
