### PR TITLE
chore: don't set the replicas if HPA is enabled

### DIFF
--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "unleash.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "unleash.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

This PR is to update the template of the `deployment` resource kind. We shouldn't set the `replicas` attribute if the HPA is enabled. This is needed when we manage the deployment of Unleash helm chart via a declarative GitOps tool like ArgoCD. The changes help to avoid the conflicts between resources (HPA & deployment's replicas). Otherwise, they will fight over the correct value.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

None

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

None
