### PR TITLE
Update chart to 2.6.1 including fix for replicas/hpa

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -16,4 +16,4 @@ sources:
   - https://github.com/Unleash/unleash-docker
   - https://github.com/Unleash/helm-charts
 type: application
-version: 2.6.0
+version: 2.6.1


### PR DESCRIPTION
This bumps the chart version, so we get a new version released that includes the fix for not using replicas in deployment descriptor if an HPA is set up
