### PR TITLE
task: Updates which k8s versions we test against

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,14 +93,14 @@ jobs:
           - v1.24.2
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
           version: v3.8.1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Set up chart-testing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,11 +85,12 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.16.15
-          - v1.17.17
-          - v1.18.15
-          - v1.19.7
-          - v1.20.2
+          - v1.19.16
+          - v1.20.15
+          - v1.21.14
+          - v1.22.11
+          - v1.23.8
+          - v1.24.2
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -98,12 +99,12 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.0
+          version: v3.8.1
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.2.1
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
@@ -112,7 +113,7 @@ jobs:
             echo "::set-output name=changed::true"
           fi
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.3.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           config: .github/kind-config.yaml


### PR DESCRIPTION
This PR updates our testing strategy to test k8s 1.19-1.24 instead of the current 1.16-1.20 versions.

kubernetes 1.21 is reading End of Life June 28 2022 (See https://kubernetes.io/releases/), so this PR is less aggressive than it could (should?) be, but at least drops 1.16-1.18.