### PR TITLE
task: updated to reflect decision regarding support strategy

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -7,8 +7,8 @@ set -o errexit
 set -o pipefail
 
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/main -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
-HELM_VERSION="v3.5.2"
-KUBEVAL_VERSION="0.15.0"
+HELM_VERSION="v3.8.1"
+KUBEVAL_VERSION="0.16.1"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"
 
 # install helm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,12 +31,12 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.0
+          version: v3.8.1
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.2.1
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
 
@@ -64,9 +64,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.16.4
-          - v1.17.4
-          - v1.18.1
+          - v1.22.11
+          - v1.23.8
+          - v1.24.2
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,9 +85,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.19.16
-          - v1.20.15
-          - v1.21.14
           - v1.22.11
           - v1.23.8
           - v1.24.2

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ You can then run `helm search repo unleash` to see the charts.
 - 1.x includes Unleash v3.x
 - 2.x includes Unleash v4.x
 
+## Kubernetes support strategy
+
+We'll build this repo on all k8s versions that have not reached End of Life according to the [Kubernetes support period](https://kubernetes.io/releases/patch-releases/#support-period).
+
+
 ## Contributing
 
 The source code of all [unleash](https://unleash.github.io/) [Helm](https://helm.sh) charts can be found on Github: <https://github.com/unleash/helm-charts/>


### PR DESCRIPTION
So, we've decided to support the versions that are currently in active support mode according to https://kubernetes.io/releases and https://kubernetes.io/releases/patch-releases/#support-period so this PR promotes our test clusters to 1.22, 1.23 and 1.24 (1.21 reached EoL today)