### PR TITLE
chore: Remove unleash-docker repo as a source

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -13,7 +13,6 @@ maintainers:
 name: unleash
 sources:
   - https://github.com/Unleash/unleash
-  - https://github.com/Unleash/unleash-docker
   - https://github.com/Unleash/helm-charts
 type: application
 version: 2.7.2


### PR DESCRIPTION
## What

This change removes the `unleash-docker` repo from the list of sources
in the `unleash/Chart.yaml` file.

## Why

The `unleash-docker` repo was archived just a few days ago because the
main `unleash` repo now contains a docker file.