### PR TITLE
fix: Updated postgresql dependency for unleash

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -15,4 +15,4 @@ sources:
   - https://github.com/Unleash/unleash
   - https://github.com/Unleash/helm-charts
 type: application
-version: 2.7.3
+version: 2.7.4

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.15.1"
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.16.2
+  version: 12.1.6
   condition: postgresql.enabled
 description: Unleash is a open source feature flag & toggle system, that gives you a great overview over all feature toggles across all your applications and services.
 maintainers:


### PR DESCRIPTION
### What
Updates the postgresql dependency to most recent version.

### Why
10.16.2 was no longer resolveable from charts.bitnami.com, so this bumps us to 12.1.6 which is still resolveable