### PR TITLE
fix: super-linter fails in 4.10.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        # https://github.com/github/super-linter/issues/1397
+        with:
+          # Full git history is needed to get a proper
+          # list of changed files within `super-linter`
+          fetch-depth: 0
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:
@@ -105,9 +110,9 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --config .github/ct.yaml)
+          changed="$(ct list-changed --config .github/ct.yaml)"
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create kind cluster
         uses: helm/kind-action@v1.3.0


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
* Fix CI `super-linter` 4.10.x as [described in super-linter issue](https://github.com/github/super-linter/issues/1397) and [from super-linter examples](https://github.com/github/super-linter/blob/main/README.md?plain=1#L169):
 
> Full git history is needed to get a proper list of changed files within `super-linter`

* Fix [github action deprecation](https://github.com/Unleash/helm-charts/actions/runs/4017009121/jobs/6900794768#step:4:74)
```
2023-01-26 16:17:32 [ERROR]   Found errors in [actionlint] linter!
2023-01-26 16:17:32 [ERROR]   Error code: 1. Command output:
------
.github/workflows/ci.yaml:112:14: workflow command "set-output" was deprecated. use `echo "{name}={value}" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]
```

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
- `.github/workflows/ci.yaml`

