### PR TITLE
Address Issue with Postgres generated secret key/values.

### DIFF
--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ if .Values.dbConfig.useExistingSecret.name }}{{ .Values.dbConfig.useExistingSecret.name }}{{ else }}{{ .Values.postgresql.fullnameOverride }}{{ end }}
-                  key: {{ if .Values.dbConfig.useExistingSecret.key }}{{ .Values.dbConfig.useExistingSecret.key }}{{ else }}postgresql-password{{ end }}
+                  key: {{ if .Values.dbConfig.useExistingSecret.key }}{{ .Values.dbConfig.useExistingSecret.key }}{{ else }}postgres-password{{ end }}
             {{- end }}
             - name: DATABASE
               value: "{{ .Values.dbConfig.database }}"
@@ -120,7 +120,7 @@ spec:
       {{- with .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
-      {{- end }}        
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When using the chart, the K8s secret values for `unleash-postgresql` which is created has the following key/value pairing:

```bash
$ kubectl get secret  unleash-postgresql -o jsonpath='{.data}'                                  
{"postgres-password":"<encoded value>"} 
```

The issue with this is that the chart is looking for a different key when attempting to create the deployment environment values.

This leads to startup issues:

```bash
$ kubectl get pods                                                                                            
NAME                       READY   STATUS                       RESTARTS   AGE
unleash-65bdd6bcbc-sgmdv   0/1     CreateContainerConfigError   0          22s
unleash-postgresql-0       1/1     Running                      0          21s

$ kubectl describe pod unleash-65bdd6bcbc-sgmdv | grep Error:
  Warning  Failed     1s (x3 over 21s)  kubelet            Error: couldn't find key postgresql-password in Secret default/unleash-postgresql
```

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files

Only one change.


## Discussion points

Is no one else seeing this issue? I tried to use old versions of the postgres chart as well and it seems like previous versions did also have this problem.