### PR TITLE
Add possibility to configure liveness and readiness probes for Unleash Proxy

### DIFF
--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -87,14 +87,24 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /proxy/health
+              path: {{ .Values.livenessProbe.path }}
               port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /proxy/health
+              path: {{ .Values.readinessProbe.path }}
               port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.edge.enable }}

--- a/charts/unleash-proxy/values.yaml
+++ b/charts/unleash-proxy/values.yaml
@@ -36,6 +36,20 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+livenessProbe:
+  enabled: true
+  path: /proxy/health
+  initialDelaySeconds: 30
+  timeoutSeconds: 10
+
+readinessProbe:
+  enabled: true
+  path: /proxy/health
+  initialDelaySeconds: 30
+  timeoutSeconds: 10
+  periodSeconds: 10
+  successThreshold: 5
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
I added the possibility to configure the liveness and the readiness probes for the Unleash Proxy.

This is important because if one hosts the proxy in a subpath, e.g. `https://mycompany.com/app/unleash-proxy`,
then the variable `PROXY_BASE_PATH` needs to be configured in the `env:` block of the `values.yaml` AND the path for the liveness and readiness probes needs to be updated too.

Before this pull request the liveness and readiness path is hardcoded to `/proxy/health`.
Now it is possible to configure it.
I simply copied the corresponding block from the `deployment.yaml` file for the Helm chart for the Unleash backend.
I also copied the default values to the `values.yaml`.

<!-- Does it close an issue? Multiple? -->
This PR does not close any issues.

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

Both files `deployment.yaml` and `values.yaml` are equally important. This is a small improvement.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

I do not know if the default values for the liveness and readiness probes for the Unleash backend also make sense for the Unleash proxy.
