### PR TITLE
Add annotations to service.

### DIFF
--- a/charts/unleash-proxy/templates/service.yaml
+++ b/charts/unleash-proxy/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "unleash-proxy.fullname" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{ toYaml . | indent 4 }}
+  {{- end }}
   labels:
     {{- include "unleash-proxy.labels" . | nindent 4 }}
 spec:

--- a/charts/unleash-proxy/values.yaml
+++ b/charts/unleash-proxy/values.yaml
@@ -39,6 +39,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
Add annotations to unleash-service proxy helm template to be able to customise service template.

**Example 1:**
Use unleash proxy behind an ingress that support GKE NEG load balancer:
```
service:
  annotations:
    cloud.google.com/neg: '{"ingress": true}' # Creates a NEG after an Ingress is created
```


## About the changes
Allow custom ingress settings for the unleash proxy service similar to unleash service chart template.

### Important files
- charts/unleash-proxy/templates/service.yaml
- charts/unleash-proxy/values.yaml

