### PR TITLE
fix: bumped unleash-proxy chart version

### DIFF
--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.13.1"
+appVersion: "v0.15.1"
 maintainers:
   - name: nkz-soft


### PR DESCRIPTION
Updates default appVersion to most recently released unleash-proxy, as well as bump the minor for the Chart, to have a release including changes for configuring health and readiness checks. 