### PR TITLE
feat: proxy support mounting secrets

### DIFF
--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -105,6 +105,12 @@ spec:
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           {{- end }}
+          {{- if .Values.mountSecretName }}
+          volumeMounts:
+          - mountPath: /mnt/secrets
+            name: mount-secrets
+            readOnly: true
+           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.edge.enable }}
@@ -141,11 +147,18 @@ spec:
             - mountPath: "/data/config"
               name: edge-features
         {{- end }}
-      {{- if .Values.edge.enable }}
+      {{- if or .Values.edge.enable .Values.mountSecretName }}
       volumes:
+        {{- if .Values.mountSecretName }}
+        - name: mount-secrets
+          secret:
+            secretName: {{ .Values.mountSecretName }}
+        {{- end }}
+        {{- if .Values.edge.enable }}
         - name: edge-features
           configMap:
             name: edge-features
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/unleash-proxy/values.yaml
+++ b/charts/unleash-proxy/values.yaml
@@ -109,6 +109,8 @@ existingSecrets:
   #       name: secretname
   #       key: secretkey
 
+# mounts the supplied secret to /mnt/secrets
+# mountSecretName: secretName
 edge:
   enable: false
 proxy:


### PR DESCRIPTION
This makes it possible to mount secrets in /mnt/secrets. This is required in order to supply custom ca certificates
