### PR TITLE
feat: Bump Edge to v7.0.0

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -4,9 +4,9 @@ name: unleash-edge
 description: A Helm chart for deploying Unleash Edge to kubernetes
 icon: https://docs.getunleash.io/img/logo.svg
 type: application
-version: 1.0.0
+version: 2.0.0
 
-appVersion: "v1.0.0"
+appVersion: "v7.0.0"
 maintainers:
   - name: chriswk
   - name: sighphyre


### PR DESCRIPTION
### What
Upgrading the Edge chart to v7.0.0, which includes all the latest yggdrasil fixes, as well as the code needed for allowing Edge to create client tokens for frontend tokens to stop 511's appearing.