### PR TITLE
task: Updated test suite to releases still not past EOL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           version: v3.11.1
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           check-latest: true
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0
@@ -69,10 +69,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - 1.23.17
-          - 1.24.11
-          - 1.25.7
-          - 1.26.2
+          - 1.24.15
+          - 1.25.11
+          - 1.26.6
+          - 1.27.3
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
         run: .github/kubeconform.sh
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
-          KUBECONFORM_VERSION: v0.6.1
+          KUBECONFORM_VERSION: v0.6.2
       - name: print tap results
         run: cat results/unleash-${{ matrix.k8s }}-result.tap
         if: always()
@@ -104,10 +104,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.23.13
-          - v1.24.7
-          - v1.25.3
-          - v1.26.2
+          - v1.24.15
+          - v1.25.11
+          - v1.26.6
+          - v1.27.3
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -116,10 +116,10 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.11.1
+          version: v3.11.2
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           check-latest: true
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0
@@ -131,7 +131,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create kind cluster
-        uses: helm/kind-action@v1.5.0
+        uses: helm/kind-action@v1.7.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           config: .github/kind-config.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: 3.11.1
+          version: 3.11.2
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0


### PR DESCRIPTION
## What
Updated test suite to 1.24, 1.25, 1.26 and 1.27.

1.24 reaches EOL July 28th (https://kubernetes.io/releases/) at which time we could update this again to only run against 1.25, 1.26 and 1.27.
