### PR TITLE
feat: Add support for static NodePort services

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -4,7 +4,7 @@ name: unleash-edge
 description: A Helm chart for deploying Unleash Edge to kubernetes
 icon: https://docs.getunleash.io/img/logo.svg
 type: application
-version: 2.0.0
+version: 2.0.1
 
 appVersion: "v7.0.0"
 maintainers:

--- a/charts/unleash-edge/templates/service.yaml
+++ b/charts/unleash-edge/templates/service.yaml
@@ -9,6 +9,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -34,8 +34,11 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  # Supported types: ClusterIP, NodePort, LoadBalancer
   type: ClusterIP
   port: 3063
+  # nodePort is optional and only used when service.type is NodePort or LoadBalancer
+  nodePort: ""
 
 resources:
   requests:

--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/unleash-proxy/templates/service.yaml
+++ b/charts/unleash-proxy/templates/service.yaml
@@ -9,6 +9,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/charts/unleash-proxy/values.yaml
+++ b/charts/unleash-proxy/values.yaml
@@ -51,8 +51,11 @@ readinessProbe:
   successThreshold: 5
 
 service:
+  # Supported types: ClusterIP, NodePort, LoadBalancer
   type: ClusterIP
   port: 80
+  # nodePort is optional and only used when service.type is NodePort or LoadBalancer
+  nodePort: ""
 
 ingress:
   enabled: false

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -15,4 +15,4 @@ sources:
   - https://github.com/Unleash/unleash
   - https://github.com/Unleash/helm-charts
 type: application
-version: 3.0.1
+version: 3.0.2

--- a/charts/unleash/templates/service.yaml
+++ b/charts/unleash/templates/service.yaml
@@ -15,6 +15,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -210,8 +210,11 @@ secrets: {}
 #  GOOGLE_CLIENT_SECRET: zzzZZz9ZZzZzZzz9Z9zZZZZZ
 
 service:
+  # Supported types: ClusterIP, NodePort, LoadBalancer
   type: ClusterIP
   port: 4242
+  # nodePort is optional and only used when service.type is NodePort or LoadBalancer
+  nodePort: ""
   annotations: {}
   ## Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service


### PR DESCRIPTION
## About the changes
Add optional 'service.nodePort' values to allow binding NodePort services for all charts via a static NodePort, as per https://kubernetes.io/docs/concepts/services-networking/service/#nodeport-custom-port

Closes #87 

### Important files
`charts/*/templates/service.yaml`
