### PR TITLE
feat(unleash): allow not mounting the default service account token

### DIFF
--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name }}
           env:

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -242,6 +242,8 @@ postgresql:
     password: unleash
     database: unleash
 
+automountServiceAccountToken: false
+
 securityContext: {}
 # Autoscaling
 # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/


### PR DESCRIPTION
## About the changes

Don't mount the default service account token as it's not required. This is more secure and allows running kube-audit asat auditor with no issue.

## Discussion points

Another solution is to use a non-default service account, same as what is done in the other two charts.