### PR TITLE
allow ssl configuration

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "5.4.4"
+appVersion: "5.5.0"
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: DATABASE_USER
               value: "{{ .Values.dbConfig.user }}"
             - name: DATABASE_SSL
-              value: "{{ .Values.dbConfig.ssl | default "false" }}"
+              value: {{ if .Values.dbConfig.ssl }}{{ .Values.dbConfig.ssl | toJson }}{{ else }}{{ "false" }}{{ end }}
             - name: DATABASE_URL
               value: "postgres://$(DATABASE_USER):$(DATABASE_PASS)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE)"
             {{- if .Values.dbConfig.schema }}

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -123,6 +123,7 @@ dbConfig:
     key: ""
   # if postgres dependency chart is used, this needs to be the same value as postgresql.auth.username
   user: unleash
+  # if not passing 'false', ssl value must be a stringified JSON object https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
   ssl: false
 
 env: []


### PR DESCRIPTION
## About the changes
SSL configuration is not able to be passed via environment variable in the helm chart. Any attempt to pass stringified JSON ([docs](https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options)) results in a Helm parsing error.

<!-- Does it close an issue? Multiple? -->
Semi related to #94 
