### PR TITLE
feat: Add support for modifying edge probe values

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -4,7 +4,7 @@ name: unleash-edge
 description: A Helm chart for deploying Unleash Edge to kubernetes
 icon: https://docs.getunleash.io/img/logo.svg
 type: application
-version: 2.0.2
+version: 2.0.3
 
 appVersion: "v11.0.2"
 maintainers:

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -52,14 +52,24 @@ spec:
             - name: http
               containerPort: 3063
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /internal-backstage/health
+              path: {{ .Values.livenessProbe.path }}
               port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /internal-backstage/health
+              path: {{ .Values.readinessProbe.path }}
               port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -52,23 +52,23 @@ spec:
             - name: http
               containerPort: 3063
               protocol: TCP
-          {{- if .Values.livenessProbe.enabled }}
+          {{- if .Values.livenessProbe.enabled | default true }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbe.path }}
+              path: {{ .Values.livenessProbe.path | default "/internal-backstage/health" }}
               port: http
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 30 }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 10 }}
           {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+          {{- if .Values.readinessProbe.enabled | default true}}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.path }}
+              path: {{ .Values.readinessProbe.path | default "/internal-backstage/health" }}
               port: http
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 30 }}
+            timeoutSeconds: {{.Values.readinessProbe.timeoutSeconds | default 10 }}
+            successThreshold: {{.Values.readinessProbe.successThreshold | default 5 }}
+            periodSeconds: {{.Values.readinessProbe.periodSeconds | default 10 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -64,19 +64,19 @@ ingress:
   #    hosts:
   #
 
-livenessProbe:
-  enabled: true
-  path: /internal-backstage/health
-  initialDelaySeconds: 30
-  timeoutSeconds: 10
+livenessProbe: {}
+#   enabled: true
+#   path: /internal-backstage/health
+#   initialDelaySeconds: 30
+#   timeoutSeconds: 10
 
-readinessProbe:
-  enabled: true
-  path: /internal-backstage/health
-  initialDelaySeconds: 30
-  timeoutSeconds: 10
-  periodSeconds: 10
-  successThreshold: 5
+readinessProbe: {}
+# enabled: true
+#   path: /internal-backstage/health
+#   initialDelaySeconds: 30
+#   timeoutSeconds: 10
+#   periodSeconds: 10
+#   successThreshold: 5
 
 autoscaling:
   enabled: false

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -64,6 +64,19 @@ ingress:
   #    hosts:
   #
 
+livenessProbe:
+  enabled: true
+  path: /internal-backstage/health
+  initialDelaySeconds: 30
+  timeoutSeconds: 10
+
+readinessProbe:
+  enabled: true
+  path: /internal-backstage/health
+  initialDelaySeconds: 30
+  timeoutSeconds: 10
+  periodSeconds: 10
+  successThreshold: 5
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
This allows BASE_PATH enviornment variable changes to be reflected in the values.yaml file. Without this, k8s will attempt to hit /internal-backstage/health, while the helm-edge application is reporting health values at /BASE_PATH/internal-backstage/health.

<!-- Does it close an issue? Multiple? -->
Closes #96

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
This change is small, important files are deployment.yaml and values.yaml


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

It could be worth discussing creating a true value for BASE_PATH in the values.yaml file instead of having to duplicate the basepath value in the helm values chart.
