### PR TITLE
feat: Bump Edge to 16.0.1, and default to json for logformat

### DIFF
--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
            {{- if .Values.existingSecrets }}
              {{- toYaml .Values.existingSecrets | nindent 12 }}
            {{- end }}
+           {{- if .Values.edge.logFormat }}
+            - name: LOG_FORMAT
+              value: "{{ .Values.edge.logFormat }}"
+           {{- end }}
            {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
            {{- end }}

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -108,3 +108,4 @@ existingSecrets:
 edge:
   upstreamUrl: "http://unleash.unleash:4242"
   logLevel: "warn"
+  logFormat: "json"


### PR DESCRIPTION
Bumping the chart version for edge and adding a configurable logFormat key which will set the LOG_FORMAT environment variable.