### PR TITLE
fix(unleash-edge): Make target port configurable

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -4,7 +4,7 @@ name: unleash-edge
 description: A Helm chart for deploying Unleash Edge to kubernetes
 icon: https://docs.getunleash.io/img/logo.svg
 type: application
-version: 2.1.1
+version: 2.1.2
 
 appVersion: "v16.0.3"
 maintainers:

--- a/charts/unleash-edge/templates/service.yaml
+++ b/charts/unleash-edge/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort | default .Values.service.port }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -37,6 +37,8 @@ service:
   # Supported types: ClusterIP, NodePort, LoadBalancer
   type: ClusterIP
   port: 3063
+  # target port will be set to port if not set
+  targetPort: ""
   # nodePort is optional and only used when service.type is NodePort or LoadBalancer
   nodePort: ""
 


### PR DESCRIPTION
As reported in #106 our Edge service always used the same targetPort as the port in the container, this PR makes it configurable while defaulting to the same as it used to.
@yuvals41 - Will this solve your issue?

fixes: #106