### PR TITLE
feat(proxy): test proxy connection with an authenticated route

### DIFF
--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/unleash-proxy/templates/tests/test-connection.yaml
+++ b/charts/unleash-proxy/templates/tests/test-connection.yaml
@@ -11,7 +11,9 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['-O -',
-             "--header='Authorization: {{ .Values.proxy.clientKeys | first }}'",
-             '{{ include "unleash-proxy.fullname" . }}:{{ .Values.service.port }}/proxy/health']
+      args: [
+        '-O', '-',
+        '--header', 'Authorization: {{ .Values.proxy.clientKeys | first }}',
+        '{{ include "unleash-proxy.fullname" . }}:{{ .Values.service.port }}/proxy'
+        ]
   restartPolicy: Never


### PR DESCRIPTION

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Update `test-connection.yaml` in the Unleash proxy Helm chart to use an authenticated route.

The currently used route `/proxy/health` does not require authentication. The Authentication header is ignored for this route. Even if there's an issue with the way client shared secrets are configured, the `test-connection.yaml` test will succeed.

Using the `/proxy` route (which does require authentication) allows testing a shared secret.

This change implements the recommended method to test the proxy deployment from
https://docs.getunleash.io/how-to/how-to-run-the-unleash-proxy#verify-that-the-proxy-is-working

Also update the way `wget` is called (the Authentication header was not correctly set, but as it was ignored this mistake was not visible).

Note: The same Helm value is used to configure the proxy shared secrets environment variable, and the authentication header in test-connection.yaml. As such, as long as the chart is correct, the user can't actually make a mistake here.

However, this test is misleading to a user reading the chart templates and manually reproducing the test against the deployed proxy, as the current test does not actually validates shared secrets.


### Important files

This change should be easy to review (it's a three line change).

I manually tested the Helm chart with this change against our environment, and checked that `helm test` still works.

## Discussion points

N/A
