### PR TITLE
chore: allow ssl configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
         with:
           version: 3.11.1
       - name: Run kubeconform tests
-        run: .github/kubeconform.sh
+        run: .github/kubeconform.sh ; cat results/*.tap
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
           KUBECONFORM_VERSION: v0.6.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,10 +83,13 @@ jobs:
         with:
           version: 3.11.1
       - name: Run kubeconform tests
-        run: .github/kubeconform.sh ; cat results/*.tap
+        run: .github/kubeconform.sh
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
           KUBECONFORM_VERSION: v0.6.1
+      - name: print tap results
+        run: cat results/unleash-${{ matrix.k8s }}-result.tap
+        if: always()
       - name: Create test summary
         uses: test-summary/action@v2
         with:

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -15,4 +15,4 @@ sources:
   - https://github.com/Unleash/unleash
   - https://github.com/Unleash/helm-charts
 type: application
-version: 3.0.5
+version: 3.0.6

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: DATABASE_USER
               value: "{{ .Values.dbConfig.user }}"
             - name: DATABASE_SSL
-              value: "{{ if .Values.dbConfig.ssl }}{{ .Values.dbConfig.ssl | toJson }}{{ else }}{{ "false" }}{{ end }}"
+              value: {{ if .Values.dbConfig.ssl }}{{ .Values.dbConfig.ssl | toJson | quote }}{{ else }}"{{ "false" }}"{{ end }}
             - name: DATABASE_URL
               value: "postgres://$(DATABASE_USER):$(DATABASE_PASS)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE)"
             {{- if .Values.dbConfig.schema }}

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: DATABASE_USER
               value: "{{ .Values.dbConfig.user }}"
             - name: DATABASE_SSL
-              value: {{ if .Values.dbConfig.ssl }}{{ .Values.dbConfig.ssl | toJson }}{{ else }}{{ "false" }}{{ end }}
+              value: "{{ if .Values.dbConfig.ssl }}{{ .Values.dbConfig.ssl | toJson }}{{ else }}{{ "false" }}{{ end }}"
             - name: DATABASE_URL
               value: "postgres://$(DATABASE_USER):$(DATABASE_PASS)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE)"
             {{- if .Values.dbConfig.schema }}

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -124,7 +124,7 @@ dbConfig:
   # if postgres dependency chart is used, this needs to be the same value as postgresql.auth.username
   user: unleash
   # if not passing 'false', ssl value must be a stringified JSON object https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
-  ssl: false
+  ssl: "false"
 
 env: []
 #  - name: GOOGLE_CLIENT_ID

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -123,7 +123,7 @@ dbConfig:
     key: ""
   # if postgres dependency chart is used, this needs to be the same value as postgresql.auth.username
   user: unleash
-  # if not passing 'false', ssl value must be a stringified JSON object https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
+  # ssl value must be a stringified JSON object https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
   # ssl: { rejectUnauthorized: false }
 
 env: []

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -124,6 +124,7 @@ dbConfig:
   # if postgres dependency chart is used, this needs to be the same value as postgresql.auth.username
   user: unleash
   # ssl value must be a stringified JSON object https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
+  ssl: false
   # ssl: { rejectUnauthorized: false }
 
 env: []

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -124,7 +124,6 @@ dbConfig:
   # if postgres dependency chart is used, this needs to be the same value as postgresql.auth.username
   user: unleash
   # ssl value must be a stringified JSON object https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
-  ssl: false
   # ssl: { rejectUnauthorized: false }
 
 env: []

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -124,7 +124,7 @@ dbConfig:
   # if postgres dependency chart is used, this needs to be the same value as postgresql.auth.username
   user: unleash
   # if not passing 'false', ssl value must be a stringified JSON object https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
-  ssl: "false"
+  # ssl: { rejectUnauthorized: false }
 
 env: []
 #  - name: GOOGLE_CLIENT_ID


### PR DESCRIPTION
## About the changes
Copied from https://github.com/Unleash/helm-charts/pull/95 to lint it

SSL configuration is not able to be passed via environment variable in the helm chart. Any attempt to pass stringified JSON ([docs](https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options)) results in a Helm parsing error.

Semi related to #94

Fixes #102
