### PR TITLE
task: bump proxy and edge version to newest available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # https://github.com/github/super-linter/issues/1397
         with:
           # Full git history is needed to get a proper
@@ -86,10 +86,7 @@ jobs:
         run: .github/kubeconform.sh
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
-          KUBECONFORM_VERSION: v0.6.1
-      - name: print tap results
-        run: cat results/unleash-${{ matrix.k8s }}-result.tap
-        if: always()
+          KUBECONFORM_VERSION: v0.6.4
       - name: Create test summary
         uses: test-summary/action@v2
         with:

--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.17.0"
+appVersion: "v1.0.0"
 maintainers:
   - name: nkz-soft

--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -122,7 +122,7 @@ spec:
               value: {{ .Values.proxy.apiToken }}
             - name: BOOTSTRAP_FILE
               value: /data/config/features.json
-          image: "unleashorg/unleash-edge:v0.5.1"
+          image: "unleashorg/unleash-edge:v16.0.6"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
As the title says, bumps proxy to 1.0.0 and edge to 16.0.6.