### PR TITLE
bug: don't set default "requests" in Unleash Edge chart values.yaml

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -4,7 +4,7 @@ name: unleash-edge
 description: A Helm chart for deploying Unleash Edge to kubernetes
 icon: https://docs.getunleash.io/img/logo.svg
 type: application
-version: 2.2.2
+version: 2.2.3
 
 appVersion: "v16.0.6"
 maintainers:

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -45,12 +45,17 @@ service:
   nodePort: ""
 
 resources:
-  requests:
-    cpu: 100m
-    memory: 64Mi
-  limits:
-    cpu: 200m
-    memory: 64Mi
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # requests:
+  #   cpu: 100m
+  #   memory: 64Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 64Mi
 
 ingress:
   enabled: false


### PR DESCRIPTION
## About the changes
Setting up default "requests" makes it impossible to omit certain portions of "requests" in local `values.yaml` file, e.g. not setting `resources.limits.cpu` is impossible. For more information see #121 

Comment taken from Unleash template to be consistent:
https://github.com/Unleash/helm-charts/blob/4cd3a4a2afec1a3048ccbafc2a7c869c64393ed4/charts/unleash/values.yaml#L193-L198

Closes #121 