### PR TITLE
fix: Don't fail builds just because we can't print a tap file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: ci
 on:
   pull_request:
     paths:
-      - 'charts/**/**'
+      - "charts/**/**"
 
 jobs:
   codespell:
@@ -86,10 +86,7 @@ jobs:
         run: .github/kubeconform.sh
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
-          KUBECONFORM_VERSION: v0.6.1
-      - name: print tap results
-        run: cat results/unleash-${{ matrix.k8s }}-result.tap
-        if: always()
+          KUBECONFORM_VERSION: v0.6.4
       - name: Create test summary
         uses: test-summary/action@v2
         with:


### PR DESCRIPTION
This was added recently to get tap results printed to stdout, but we already add the tap results to the summary of the workflow, so that this breaking should cause the build to break seems wrong to me.

This PR removes the stdout printing of tap, but keeps the add test-summary action so we still get tap results attached to the workflow run.