### PR TITLE
feat: Add optional startup probe and simplify liveness and readiness probes

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -4,7 +4,7 @@ name: unleash-edge
 description: A Helm chart for deploying Unleash Edge to kubernetes
 icon: https://docs.getunleash.io/img/logo.svg
 type: application
-version: 2.2.3
+version: 2.3.0
 
 appVersion: "v16.0.6"
 maintainers:

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -59,23 +59,35 @@ spec:
             - name: http
               containerPort: 3063
               protocol: TCP
-          {{- if .Values.livenessProbe.enabled | default true }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.livenessProbe.path | default "/internal-backstage/health" }}
-              port: http
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 30 }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 10 }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.readinessProbe.enabled | default true}}
-          readinessProbe:
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+          {{- if .enabled | default false }}
             httpGet:
-              path: {{ .Values.readinessProbe.path | default "/internal-backstage/health" }}
+              path: {{ .path | default "/internal-backstage/health" }}
               port: http
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 30 }}
-            timeoutSeconds: {{.Values.readinessProbe.timeoutSeconds | default 10 }}
-            successThreshold: {{.Values.readinessProbe.successThreshold | default 5 }}
-            periodSeconds: {{.Values.readinessProbe.periodSeconds | default 10 }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 30 }}
+            timeoutSeconds: {{ .timeoutSeconds | default 10 }}
+          {{- else }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+          {{- if .enabled | default false }}
+            httpGet:
+              path: {{ .path | default "/internal-backstage/health" }}
+              port: http
+            initialDelaySeconds: {{ .initialDelaySeconds | default 30 }}
+            timeoutSeconds: {{ .timeoutSeconds | default 10 }}
+            successThreshold: {{ .successThreshold | default 5 }}
+            periodSeconds: {{ .periodSeconds | default 10 }}
+          {{- else }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{ with .Values.volumeMounts }}
           volumeMounts:

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -73,19 +73,39 @@ ingress:
   #    hosts:
   #
 
-livenessProbe: {}
-#   enabled: true
-#   path: /internal-backstage/health
-#   initialDelaySeconds: 30
-#   timeoutSeconds: 10
+startupProbe:
+  {}
+  # exec:
+  #   command: ["/unleash-edge", "ready"]
+  # initialDelaySeconds: 10
+  # timeoutSeconds: 10
+  # periodSeconds: 10
+  # successThreshold: 1
+  # failureThreshold: 10
 
-readinessProbe: {}
-# enabled: true
-#   path: /internal-backstage/health
-#   initialDelaySeconds: 30
-#   timeoutSeconds: 10
-#   periodSeconds: 10
-#   successThreshold: 5
+livenessProbe:
+  exec:
+    command: ["/unleash-edge", "health"]
+  # httpGet:
+  #   path: /internal-backstage/health
+  #   port: http
+  initialDelaySeconds: 10
+  timeoutSeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 5
+
+readinessProbe:
+  exec:
+    command: ["/unleash-edge", "health"]
+  # httpGet:
+  #   path: /internal-backstage/health
+  #   port: http
+  initialDelaySeconds: 10
+  timeoutSeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 1
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
This PR adds a mechanism for users to define a startup probe where failure to hot load edge containers with flags blocks startup.

If we like this approach, we copy the simplification to other charts.
