### PR TITLE
chore: update Unleash Edge to most recent version

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 type: application
 version: 2.3.1
 
-appVersion: "v17.0.0"
+appVersion: "v18.0.0"
 maintainers:
   - name: chriswk
   - name: sighphyre

--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -4,9 +4,9 @@ name: unleash-edge
 description: A Helm chart for deploying Unleash Edge to kubernetes
 icon: https://docs.getunleash.io/img/logo.svg
 type: application
-version: 2.3.0
+version: 2.3.1
 
-appVersion: "v16.0.6"
+appVersion: "v17.0.0"
 maintainers:
   - name: chriswk
   - name: sighphyre


### PR DESCRIPTION
As it says in the title. We released 17.0.0 yesterday, so this bumps the helm chart to use that.