### PR TITLE
fix: make existing secrets an array of secret refs

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -15,4 +15,4 @@ sources:
   - https://github.com/Unleash/unleash
   - https://github.com/Unleash/helm-charts
 type: application
-version: 3.1.4
+version: 4.0.0

--- a/charts/unleash/examples/existingSecrets.yaml
+++ b/charts/unleash/examples/existingSecrets.yaml
@@ -1,0 +1,6 @@
+existingSecrets:
+  - name: GOOGLE_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: secretname
+        key: secretkey

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -68,8 +68,15 @@ spec:
                   key: {{ $key }}
             {{- end }}
             {{- end }}
-            {{- with .Values.existingSecrets }}
-              {{- tpl . $ | nindent 12 }}
+            {{ if .Values.existingSecrets}}
+            {{- range .Values.existingSecrets }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .valueFrom.secretKeyRef.name }}
+                  key: {{ .valueFrom.secretKeyRef.key }}
+            {{- end }}
+            {{- end }}
             {{- end }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -77,7 +77,6 @@ spec:
                   key: {{ .valueFrom.secretKeyRef.key }}
             {{- end }}
             {{- end }}
-            {{- end }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -133,8 +133,7 @@ env: []
 #    value: https://unleash.example.com/api/auth/callback
 
 # adds environmentvars for existing secrets to the container via tpl function
-existingSecrets:
-  ""
+existingSecrets: []
   # - name: GOOGLE_CLIENT_SECRET
   #   valueFrom:
   #     secretKeyRef:


### PR DESCRIPTION
Our previous implementation for existingSecrets expected a string from our values file that had to be escaped using the `|`  to mark a block style with newlines preserved.

 This PR changes to expect a list of secret key references, and then extracts the values from the secret reference. See the example file. 