### PR TITLE
feat: added configurable DATABASE_SSL_* possibilities

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "5.9.6"
+appVersion: "5.11.3"
 dependencies:
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
@@ -15,4 +15,4 @@ sources:
   - https://github.com/Unleash/unleash
   - https://github.com/Unleash/helm-charts
 type: application
-version: 4.0.2
+version: 4.1.0

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "5.11.3"
+appVersion: "5.12.0"
 dependencies:
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami

--- a/charts/unleash/examples/sslConfigFile.yaml
+++ b/charts/unleash/examples/sslConfigFile.yaml
@@ -1,0 +1,4 @@
+postgresql:
+  enabled: false
+dbConfig:
+  sslConfigFile: /var/run/secrets/unleash/ssl-config.json

--- a/charts/unleash/examples/sslFiles.yaml
+++ b/charts/unleash/examples/sslFiles.yaml
@@ -1,7 +1,7 @@
 dbConfig:
   sslCaFile: /var/run/secrets/kubernetes/amazon-rds-ca-bundle.pem
   sslCertFile: /var/run/secrets/kubernetes/my-client-cert.crt
-  sslKeyFile: /var/run/secrets/kubernetes/my-client-key.crt
+  sslKeyFile: /var/run/secrets/kubernetes/my-client-key.key
   sslRejectUnauthorized: false
 postgresql:
   enabled: false

--- a/charts/unleash/examples/sslFiles.yaml
+++ b/charts/unleash/examples/sslFiles.yaml
@@ -1,0 +1,7 @@
+dbConfig:
+  sslCaFile: /var/run/secrets/kubernetes/amazon-rds-ca-bundle.pem
+  sslCertFile: /var/run/secrets/kubernetes/my-client-cert.crt
+  sslKeyFile: /var/run/secrets/kubernetes/my-client-key.crt
+  sslRejectUnauthorized: false
+postgresql:
+  enabled: false

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -48,11 +48,33 @@ spec:
               value: "{{ .Values.dbConfig.port }}"
             - name: DATABASE_USERNAME
               value: "{{ .Values.dbConfig.user }}"
+            {{- if .Values.dbConfig.ssl }}
             - name: DATABASE_SSL
-              value: {{ if .Values.dbConfig.ssl }}{{ .Values.dbConfig.ssl | toJson | quote }}{{ else }}"{{ "false" }}"{{ end }}
+              value: {{ .Values.dbConfig.ssl | toJson | quote }}
+            {{- end }}
             {{- if .Values.dbConfig.schema }}
             - name: DATABASE_SCHEMA
               value: "{{ .Values.dbConfig.schema }}"
+            {{- end }}
+            {{- if .Values.dbConfig.sslConfigFile }}
+            - name: DATABASE_SSL_CA_CONFIG
+              value: "{{ .Values.dbConfig.sslConfigFile }}"
+            {{- end }}
+            {{- if .Values.dbConfig.sslCaFile }}
+            - name: DATABASE_SSL_CA_FILE
+              value: "{{ .Values.dbConfig.sslCaFile }}"
+            {{- end }}
+            {{- if .Values.dbConfig.sslKeyFile }}
+            - name: DATABASE_SSL_KEY_FILE
+              value: "{{ .Values.dbConfig.sslKeyFile }}"
+            {{- end }}
+            {{- if .Values.dbConfig.sslCertFile }}
+            - name: DATABASE_SSL_CERT_FILE
+              value: "{{ .Values.dbConfig.sslCertFile }}"
+            {{- end }}
+            {{- if .Values.dbConfig.sslRejectUnauthorized }}
+            - name: DATABASE_SSL_REJECT_UNAUTHORIZED
+              value: "{{ .Values.dbConfig.sslRejectUnauthorizaed }}"
             {{- end }}
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -126,6 +126,16 @@ dbConfig:
   user: unleash
   # ssl value must be a stringified JSON object https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
   # ssl: { rejectUnauthorized: false }
+  # sslConfigFile can be a path to a json file containing the keys listed in https://docs.getunleash.io/reference/deploy/configuring-unleash#dbssl-vs-database_ssl-options
+  # sslConfigFile:
+  # sslCaFile should be a path to a CA file in pem format
+  # sslCaFile:
+  # sslCertFile should be a path to the cert file in pem format to use to connect to postgres
+  # sslCertFile:
+  # sslKeyFile should be a path to the key file in pem format to use to connect to postgres
+  # sslKeyFile:
+  # sslRejectUnauthorized can be set to true|false. Don't set this to false in production, it will void any security you get from using SSL to connect
+  # sslRejectUnauthorized
 
 env: []
 #  - name: GOOGLE_CLIENT_ID


### PR DESCRIPTION
Related to Unleash#6718 - This allows Helm users to configure the new environment variables.

It will not work on current 5.11.3, will have to wait for 5.12.0 before it becomes relevant.