### PR TITLE
make target port customisable for unleash helm chart

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -15,4 +15,4 @@ sources:
   - https://github.com/Unleash/unleash
   - https://github.com/Unleash/helm-charts
 type: application
-version: 4.0.2
+version: 4.0.3

--- a/charts/unleash/templates/service.yaml
+++ b/charts/unleash/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort | default .Values.service.port }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -226,6 +226,8 @@ service:
   # Supported types: ClusterIP, NodePort, LoadBalancer
   type: ClusterIP
   port: 4242
+  # target port will be set to port if not set
+  targetPort: ""
   # nodePort is optional and only used when service.type is NodePort or LoadBalancer
   nodePort: ""
   annotations: {}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
This allows you to make the target port customisable for the unleash service.

<!-- Does it close an issue? Multiple? -->
There is no open issue for it.. but it is the same as this change that was done for the unleash-edge helm chart - https://github.com/Unleash/helm-charts/issues/106

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
