### PR TITLE
fix: ssl needs to be disabled when postgres enabled

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 4.2.1
+version: 4.2.2
 
 appVersion: "5.12.2"
 

--- a/charts/unleash/examples/debugLogging.yaml
+++ b/charts/unleash/examples/debugLogging.yaml
@@ -1,0 +1,8 @@
+env:
+  - name: LOG_LEVEL
+    value: debug
+  - name: MIGRATION_LOCK
+    value: "false"
+  - name: DATABASE_SSL
+    value: "false"
+

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
             - name: DATABASE_SSL
               value: {{ .Values.dbConfig.ssl | toJson | quote }}
             {{- end }}
+            {{ if !.Values.dbConfig.ssl and .Values.postgresql.enabled }}
+            - name: DATABASE_SSL
+              value: "false"
+            {{- end }}
             {{- if .Values.dbConfig.schema }}
             - name: DATABASE_SCHEMA
               value: "{{ .Values.dbConfig.schema }}"

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -51,8 +51,7 @@ spec:
             {{- if .Values.dbConfig.ssl }}
             - name: DATABASE_SSL
               value: {{ .Values.dbConfig.ssl | toJson | quote }}
-            {{- end }}
-            {{ if !.Values.dbConfig.ssl and .Values.postgresql.enabled }}
+            {{- else if .Values.postgresql.enabled }}
             - name: DATABASE_SSL
               value: "false"
             {{- end }}


### PR DESCRIPTION
As the title says, our included postgres chart does not configure SSL connections, so DATABASE_SSL needs to be set to false when starting with included chart. If you've made the effort to configure ssl, you can still override DATABASE_SSL with dbConfig.ssl even with postgres enabled.