### PR TITLE
chore: bumped to supported k8s versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,10 +69,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - 1.23.17
-          - 1.24.11
-          - 1.25.7
-          - 1.26.2
+          - 1.26.15
+          - 1.27.14
+          - 1.28.10
+          - 1.29.5
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -101,10 +101,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.23.13
-          - v1.24.7
-          - v1.25.3
-          - v1.26.2
+          - v1.26.15
+          - v1.27.14
+          - v1.28.10
+          - v1.29.5
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,10 @@ on:
 jobs:
   codespell:
     name: codespell
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@master
         with:
@@ -25,19 +25,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
+      - uses: actions/setup-python@v5
         with:
-          version: v3.11.1
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
+          python-version: '3.x'
           check-latest: true
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.0
+        uses: helm/chart-testing-action@v2.6.1
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
 
@@ -45,14 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # https://github.com/github/super-linter/issues/1397
         with:
           # Full git history is needed to get a proper
           # list of changed files within `super-linter`
           fetch-depth: 0
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: super-linter/super-linter@v6.5.0
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,18 +73,16 @@ jobs:
           - 1.29.5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup helm
-        uses: azure/setup-helm@v3
-        with:
-          version: 3.11.1
+        uses: azure/setup-helm@v4.2.0
       - name: Run kubeconform tests
         run: .github/kubeconform.sh
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
-          KUBECONFORM_VERSION: v0.6.4
+          KUBECONFORM_VERSION: v0.6.6
       - name: Create test summary
         uses: test-summary/action@v2
         with:
@@ -95,7 +91,7 @@ jobs:
 
   install-chart:
     name: install-chart
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - kubeconform
     strategy:
@@ -107,19 +103,17 @@ jobs:
           - v1.29.5
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4.2.0
+      - uses: actions/setup-python@v5
         with:
-          version: v3.11.1
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
+          python-version: '3.x'
           check-latest: true
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.0
+        uses: helm/chart-testing-action@v2.6.1
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
@@ -128,7 +122,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create kind cluster
-        uses: helm/kind-action@v1.5.0
+        uses: helm/kind-action@v1
         if: steps.list-changed.outputs.changed == 'true'
         with:
           config: .github/kind-config.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -20,11 +20,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: 3.11.1
+        uses: azure/setup-helm@v4.2.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/sync-readme.yaml
+++ b/.github/workflows/sync-readme.yaml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: |
           cp -f README.md ${{ runner.temp }}/README.md


### PR DESCRIPTION
Since 1.26 reached eol in February 2024, this PR includes it, but we'll need to do another shift this fall, to include 1.30, and exclude 1.26