### PR TITLE
chore: Bump default edge version to latest bugfix

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,9 +5,9 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 2.6.0
+version: 2.6.1
 
-appVersion: "v19.0.0"
+appVersion: "v19.1.3"
 
 maintainers:
   - name: chriswk


### PR DESCRIPTION
Include latest bugfix in our helm-chart