### PR TITLE
fix: Include name helper for container name in all three charts

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 2.6.1
+version: 2.6.2
 
 appVersion: "v19.1.3"
 

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "unleash.name" . }}
           args: ["edge"]
           env:
             - name: UPSTREAM_URL

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "unleash.name" . }}
+        - name: {{ include "unleash-edge.name" . }}
           args: ["edge"]
           env:
             - name: UPSTREAM_URL

--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.17.0"
+appVersion: "v1.3.0"
 
 maintainers:
   - name: nkz-soft

--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "unleash-proxy.name" . }}
           env:
             {{- if .Values.proxy.apiTokenSecret.enabled }}
             - name: UNLEASH_API_TOKEN

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 5.1.0
+version: 5.1.1
 
 appVersion: "6.0.0"
 

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "unleash.serviceAccountName" . }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "unleash.name" . }}
           env:
             {{- if or (.Values.dbConfig.useExistingSecret.name) (.Values.postgresql.enabled) }}
             - name: POSTGRESQL_PASSWORD


### PR DESCRIPTION
This allows you to use nameOverride if you don't want to use the Chart.name as your container name.

fixes: #153

