### PR TITLE
task: updates versions of edge and unleash

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,9 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_KUBERNETES_KUBEVAL: false
           VALIDATE_YAML: false
+          VALIDATE_KUBERNETES_KUBECONFORM: false
+          VALIDATE_CHECKOV: false
+
   kubeconform:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,9 +101,9 @@ jobs:
       matrix:
         k8s:
           - v1.26.15
-          - v1.27.14
-          - v1.28.10
-          - v1.29.5
+          - v1.27.13
+          - v1.28.9
+          - v1.29.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,9 +5,9 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 2.6.2
+version: 2.6.3
 
-appVersion: "v19.1.3"
+appVersion: "v19.2.0"
 
 maintainers:
   - name: chriswk

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,9 +5,9 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 5.1.1
+version: 5.1.2
 
-appVersion: "6.0.0"
+appVersion: "6.0.6"
 
 dependencies:
   - name: postgresql

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             {{- end }}
             {{- if .Values.dbConfig.sslRejectUnauthorized }}
             - name: DATABASE_SSL_REJECT_UNAUTHORIZED
-              value: "{{ .Values.dbConfig.sslRejectUnauthorizaed }}"
+              value: "{{ .Values.dbConfig.sslRejectUnauthorized }}"
             {{- end }}
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}


### PR DESCRIPTION
As it says on the tin. Makes Edge 19.2.0 and Unleash 6.0.6 the new defaults for the charts