### PR TITLE
Allow dnsConfig for unleash proxy

### DIFF
--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4
+version: 0.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.5
+version: 0.8.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -186,3 +186,7 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/unleash-proxy/values.yaml
+++ b/charts/unleash-proxy/values.yaml
@@ -105,6 +105,11 @@ topologySpreadConstraints: {}
   #   topologyKey: topology.kubernetes.io/zone
   #   whenUnsatisfiable: DoNotSchedule
 
+dnsConfig: {}
+  # options:
+  #   - name: ndots
+  #     value: "1"
+
 # Adds environment variables
 env: []
 #  - name: LOG_LEVEL


### PR DESCRIPTION
## About the changes

There are DNS issues in Alpine, which affects Unleash Proxy deployments on some Kubernetes clusters. Possible workaround is adding `dnsConfig` to Pod spec:

```yaml
dnsConfig:
  options:
    - name: ndots
      value: "1"
```

This PR allows configuring `dnsConfig` in Unleash Proxy chart to address that.