### PR TITLE
fix: bump proxy version and fix edge deployment for ipv6 stacks

### DIFF
--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.6
+version: 0.8.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.3.0"
+appVersion: "v1.4.4"
 
 maintainers:
   - name: nkz-soft

--- a/charts/unleash-proxy/ci/unleash-proxy-values.yaml
+++ b/charts/unleash-proxy/ci/unleash-proxy-values.yaml
@@ -8,3 +8,4 @@ autoscaling:
 
 edge:
   enable: true
+  version: 19.3.0

--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -126,11 +126,17 @@ spec:
               value: {{ .Values.proxy.apiToken }}
             - name: BOOTSTRAP_FILE
               value: /data/config/features.json
-          image: "unleashorg/unleash-edge:v0.5.1"
+            - name: PORT
+              value: "{{ .Values.edge.port }}"
+            - name: WORKERS
+              value: "1"
+            - name: INTERFACE
+              value: "::"
+          image: "unleashorg/unleash-edge:v{{ .Values.edge.version }}"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 3063
+              containerPort: {{ .Values.edge.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -139,7 +145,7 @@ spec:
           readinessProbe:
             httpGet:
               port: http
-              path: /internal-backstage/health
+              path: /internal-backstage/ready
           resources:
             limits:
               cpu: 50m

--- a/charts/unleash-proxy/values.yaml
+++ b/charts/unleash-proxy/values.yaml
@@ -128,6 +128,7 @@ existingSecrets:
 # mountSecretName: secretName
 edge:
   enable: false
+  port: 3063
 proxy:
   serverHost: http://unleash:4242/api
   apiToken: "default:development.unleash-insecure-api-token"


### PR DESCRIPTION
So, turns out the new k8s'es default to ipv6 stacks, so `localhost` resolved to `::1`. By default, we mount to 0.0.0.0 in Edge, which listens to all ipv4 interfaces, but not to ipv6. This PR changes the Edge deployment to by default mount to `::` which in dual stack setup means localhost again resolves to Edge.