### PR TITLE
feat: allow custom labels to ingress

### DIFF
--- a/charts/unleash/templates/ingress.yaml
+++ b/charts/unleash/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "unleash.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -102,6 +102,7 @@ ingress:
     {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   hosts:
     - host: chart-example.local
       paths:


### PR DESCRIPTION
## About the changes
Adds `ingress.labels` to values, allowing consumers to add custom labels to the ingress. Our company use labels on ingresses and routes to set them up for traffic from specific domains.
