### PR TITLE
add deploymentAnnotations to each chart

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 2.7.1
+version: 2.7.2
 
 appVersion: "v19.5.1"
 

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "unleash-edge.fullname" . }}
+  annotations:
+    {{- include "unleash-edge.deploymentAnnotations" . | nindent 4 }}
   labels:
     {{- include "unleash-edge.labels" . | nindent 4 }}
 spec:

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -3,8 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "unleash-edge.fullname" . }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
-    {{- include "unleash-edge.deploymentAnnotations" . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "unleash-edge.labels" . | nindent 4 }}
 spec:

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -20,6 +20,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 podLabels: {}

--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.8
+version: 0.8.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "unleash-proxy.fullname" . }}
+  annotations:
+    {{- include "unleash-proxy.deploymentAnnotations" . | nindent 4 }}
   labels:
     {{- include "unleash-proxy.labels" . | nindent 4 }}
 spec:

--- a/charts/unleash-proxy/templates/deployment.yaml
+++ b/charts/unleash-proxy/templates/deployment.yaml
@@ -3,8 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "unleash-proxy.fullname" . }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
-    {{- include "unleash-proxy.deploymentAnnotations" . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "unleash-proxy.labels" . | nindent 4 }}
 spec:

--- a/charts/unleash-proxy/values.yaml
+++ b/charts/unleash-proxy/values.yaml
@@ -23,6 +23,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 podLabels: {}

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 5.3.0
+version: 5.3.1
 
 appVersion: "6.3.0"
 

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "unleash.fullname" . }}
+  annotations:
+    {{- include "unleash.deploymentAnnotations" . | nindent 4 }}
   labels:
     {{- include "unleash.labels" . | nindent 4 }}
 spec:

--- a/charts/unleash/templates/deployment.yaml
+++ b/charts/unleash/templates/deployment.yaml
@@ -3,8 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "unleash.fullname" . }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
-    {{- include "unleash.deploymentAnnotations" . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "unleash.labels" . | nindent 4 }}
 spec:

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -125,6 +125,8 @@ nameOverride: ""
 
 nodeSelector: {}
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 readinessProbe:


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
For each chart, this adds a new value called `deploymentAnnotations`. This allows users to set annotations on the Deployment object similarly to how `podAnnotations` sets them on the Pods.

I would like to use this to set an annotation that allows [Reloader](https://github.com/stakater/Reloader) to refresh my instance of Unleash Proxy if and when the secret containing the client key gets changed. I added it to each chart for consistency.

<!-- Does it close an issue? Multiple? -->
No open issue

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
I followed the implementation of `podAnnotations` here so that the 'with' keyword would only add the annotations block when `deploymentAnnotations` is not blank. 

Also bumped each Chart version number. Let me know if this is not desired.
