### PR TITLE
Potential fix for issue https://github.com/Unleash/unleash/issues/9111

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,8 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 2.7.4
-
+version: 3.0.0
 appVersion: "v19.6.1"
 
 maintainers:

--- a/charts/unleash-edge/ci/unleash-edge-values.yaml
+++ b/charts/unleash-edge/ci/unleash-edge-values.yaml
@@ -6,6 +6,8 @@ autoscaling:
 ingress:
   enabled: true
 
+existingSecrets: ""
+
 edge:
   upstreamUrl: "http://unleash:4242"
 

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
            {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
            {{- end }}
-          {{- if not (quote .Values.existingSecrets | empty) }}
+          {{- if .Values.existingSecrets }}
           envFrom:
             - secretRef:
                 name: {{ .Values.existingSecrets }}

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -45,9 +45,6 @@ spec:
             - name: RUST_LOG
               value: "{{ .Values.edge.logLevel }}"
            {{- end }}
-           {{- if .Values.existingSecrets }}
-             {{- toYaml .Values.existingSecrets | nindent 12 }}
-           {{- end }}
            {{- if .Values.edge.logFormat }}
             - name: LOG_FORMAT
               value: "{{ .Values.edge.logFormat }}"
@@ -55,6 +52,11 @@ spec:
            {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
            {{- end }}
+          {{- if not (quote .Values.existingSecrets | empty) }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecrets }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -169,11 +169,7 @@ extraObjects: []
 # adds environmentvars for existing secrets to the container via tpl function
 existingSecrets:
   ""
-  # - name: TOKENS
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: secretname
-  #       key: secretkey
+  # Name of the secret containing key value pairs
 
 edge:
   upstreamUrl: "http://unleash.unleash:4242"


### PR DESCRIPTION
# Fix existingSecrets implementation in unleash-edge chart
 
## Description
This PR fixes the implementation of `existingSecrets` in the unleash-edge Helm chart which currently causes Kubernetes validation errors when deploying with secret configurations. The issue is documented in [unleash#9111](https://github.com/Unleash/unleash/issues/9111).
 
## Changes
1. Modified deploment.yaml default to use envFrom to load secrets
```yaml
{{- if Values.existingSecrets }}
envFrom:
  - secretRef:
      name: {{ .Values.existingSecrets }}
{{- end }}
```
 
2. Updated the deployment template to use `envFrom` instead of trying to merge secrets into `env` section, which prevents validation errors with environment variables.
 
## Testing
- Deployed chart with empty secrets configuration (works)
- Deployed chart with secrets configured:
```yaml
existingSecrets: custom-user-secret  # references existing secret
```
- Verified deployment completes without validation errors
- Verified environment variables are properly set in the container
 
## Additional Notes
- This is a breaking change as it modifies how secrets are configured
- Users will need to update their values.yaml to use the new secret reference format
- The new implementation is more aligned with Kubernetes best practices for secret management
 
## Related Issues
- Fixes [unleash#9111](https://github.com/Unleash/unleash/issues/9111)