### PR TITLE
task: bump Unleash version to 6.10.0

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,9 +5,9 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 5.4.3
+version: 5.5.0
 
-appVersion: "6.7.2"
+appVersion: "6.10.0"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
Ref #191 

Though we do allow you to override the image tag in your values file. This now defaults to Unleash 6.10.0