### PR TITLE
fix: docker image has moved binary, update checks

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 3.0.1
+version: 3.0.2
 appVersion: "v19.10.1"
 
 maintainers:

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -102,7 +102,9 @@ livenessProbe:
 
 readinessProbe:
   exec:
-    command: ["/app/unleash-edge", "ready"]
+    command: ["/app/unleash-edge", "health"]
+  # Could also use /app/unleash-edge ready here, but since we aren't guaranteed to startup with tokens
+  # the pod might never enter ready state
   # httpGet:
   #   path: /internal-backstage/ready
   #   port: http

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -90,7 +90,7 @@ startupProbe:
 
 livenessProbe:
   exec:
-    command: ["/unleash-edge", "health"]
+    command: ["/app/unleash-edge", "health"]
   # httpGet:
   #   path: /internal-backstage/health
   #   port: http
@@ -102,9 +102,9 @@ livenessProbe:
 
 readinessProbe:
   exec:
-    command: ["/unleash-edge", "health"]
+    command: ["/app/unleash-edge", "ready"]
   # httpGet:
-  #   path: /internal-backstage/health
+  #   path: /internal-backstage/ready
   #   port: http
   initialDelaySeconds: 10
   timeoutSeconds: 10


### PR DESCRIPTION
Since we migrated to chef build, the docker image now puts the binary in /app/unleash-edge instead of /unleash-edge. This updates the health check to use the correct path. 

fixes #194 