### PR TITLE
task: update chart with newest edge version

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,8 +5,8 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 3.0.2
-appVersion: "v19.10.1"
+version: 3.0.3
+appVersion: "v19.11.1"
 
 maintainers:
   - name: chriswk


### PR DESCRIPTION
As the comment says. We just released v19.11.1 to fix a bug with failure to initialize TLS for redis connections. So this PR bumps Edge to that version.