### PR TITLE
feat: added serviceMonitor support for unleash and unleash-edge charts

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 type: application
 
 version: 3.0.4
-appVersion: "v19.11.1"
+appVersion: "v19.11.3"
 
 maintainers:
   - name: chriswk

--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 3.0.3
+version: 3.0.4
 appVersion: "v19.11.1"
 
 maintainers:

--- a/charts/unleash-edge/examples/extraLabelsForServiceMonitor.yaml
+++ b/charts/unleash-edge/examples/extraLabelsForServiceMonitor.yaml
@@ -1,0 +1,7 @@
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    app.kubernetes.io/part-of: unleash
+    app.kubernetes.io/component: service-monitor
+  extraSelectorLabels:
+    app.kubernetes.io/part-of: unleash

--- a/charts/unleash-edge/templates/serviceMonitor.yaml
+++ b/charts/unleash-edge/templates/serviceMonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: unleash-edge-service-monitor
+  labels:
+    {{- include "unleash-edge.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.extraLabels }}
+      {{- toYaml .Values.serviceMonitor.extraLabels | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "unleash-edge.selectorLabels" . | nindent 8 }}
+      {{- if .Values.serviceMonitor.extraSelectorLabels }}
+        {{- toYaml .Values.serviceMonitor.extraSelectorLabels | nindent 8 }}
+      {{- end }}
+  endpoints:
+  - port: http
+    path: /internal-backstage/metrics
+{{- end }}

--- a/charts/unleash-edge/templates/serviceMonitor.yaml
+++ b/charts/unleash-edge/templates/serviceMonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.serviceMonitor .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -184,3 +184,8 @@ podDisruptionBudget:
   maxUnavailable: 1
 
 priorityClassName: ""
+
+serviceMonitor:
+  enabled: false
+  extraLabels: {}
+  extraSelectorLabels: {}

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 5.6.0
+version: 5.6.1
 
 appVersion: "7.0.1"
 

--- a/charts/unleash/templates/serviceMonitor.yaml
+++ b/charts/unleash/templates/serviceMonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: unleash-service-monitor
+  labels:
+    {{- include "unleash.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.extraLabels }}
+      {{- toYaml .Values.serviceMonitor.extraLabels | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "unleash.selectorLabels" . | nindent 8 }}
+      {{- if .Values.serviceMonitor.extraSelectorLabels }}
+        {{- toYaml .Values.serviceMonitor.extraSelectorLabels | nindent 8 }}
+      {{- end }}
+  endpoints:
+  - port: http
+    path: /internal-backstage/prometheus
+{{- end }}

--- a/charts/unleash/templates/serviceMonitor.yaml
+++ b/charts/unleash/templates/serviceMonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.serviceMonitor .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -290,3 +290,8 @@ topologySpreadConstraints:
 # Add additional volumes and mounts, for example to read other secrets.
 volumes: []
 volumeMounts: []
+
+serviceMonitor:
+  enabled: false
+  extraLabels: {}
+  extraSelectorLabels: {}


### PR DESCRIPTION
As requested in #196 . This PR adds support for ServiceMonitors for Unleash and Unleash-Edge charts.

Disabled by default, but enabled by setting serviceMonitor.enabled=true.


Should fix #196 