### PR TITLE
chore(security): upgrade to 7.0.5

### DIFF
--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 5.6.1
+version: 5.6.2
 
 appVersion: "7.0.5"
 


### PR DESCRIPTION
This fixes CVE-2025-27210 https://nodejs.org/en/blog/vulnerability/july-2025-security-releases
