### PR TITLE
chore: Update appversion for edge

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,8 +5,8 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 3.0.4
-appVersion: "v19.11.3"
+version: 3.0.5
+appVersion: "v19.14.1"
 
 maintainers:
   - name: chriswk


### PR DESCRIPTION
We just released 19.14.1, this updates the chart to use that as its appVersion

