### PR TITLE
chore: bump appVersion for unleash and unleash-edge

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,8 +5,8 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 3.0.6
-appVersion: "v19.14.2"
+version: 3.0.7
+appVersion: "v19.15.1"
 
 maintainers:
   - name: chriswk

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,9 +5,9 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 5.6.2
+version: 5.6.3
 
-appVersion: "7.0.5"
+appVersion: "7.1.0"
 
 dependencies:
   - name: postgresql

--- a/charts/unleash/examples/volumes.yaml
+++ b/charts/unleash/examples/volumes.yaml
@@ -1,0 +1,7 @@
+volumeMounts:
+  - name: rds-ca
+    mountPath: /var/run/secrets
+volumes:
+  - name: rds-ca
+    secret:
+      secretName: rds-ca-cert


### PR DESCRIPTION
As the title says, bumps to 7.1.0 for Unleash and 19.15.1 for Edge. 