### PR TITLE
chore(actions): maintain action versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "charts/**/**"
+  workflow_dispatch:
+
 
 jobs:
   codespell:


### PR DESCRIPTION
As the title says, updates action versions to most recently released one to hopefully support python 3.12