### PR TITLE
fix: add CR_SKIP_EXISTING to chart release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,3 +26,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"


### PR DESCRIPTION
Fix the chart release process to skip existing versions if nothing changed. 