### PR TITLE
feat: Add HTTPRoute support for Gateway API

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 3.1.4
+version: 3.1.5
 appVersion: "v20.1.10"
 
 maintainers:

--- a/charts/unleash-edge/templates/httproute.yaml
+++ b/charts/unleash-edge/templates/httproute.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "unleash-edge.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "unleash-edge.labels" . | nindent 4 }}
+    {{- with .Values.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httproute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httproute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -81,6 +81,42 @@ ingress:
   #    hosts:
   #
 
+# Gateway API HTTPRoute configuration
+# Ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+httproute:
+  # -- Enable HTTPRoute resource (Gateway API)
+  enabled: false
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Gateway API parentRefs for the HTTPRoute
+  # Must reference an existing Gateway resource
+  parentRefs: []
+    # - name: example-gateway
+    #   namespace: example-gateway-namespace
+    #   sectionName: https
+  # -- List of hostnames for the HTTPRoute
+  hostnames: []
+    # - unleash-edge.example.com
+  # -- HTTPRoute rules configuration
+  # Note: backendRefs in custom rules will be ignored;
+  # the chart service is always used as the backend.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # filters: []
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Custom-Header
+      #           value: custom-value
+      # timeouts:
+      #   request: 10s
+      #   backendRequest: 2s
+
 startupProbe:
   {}
   # exec:

--- a/charts/unleash-enterprise/Chart.yaml
+++ b/charts/unleash-enterprise/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 1.0.2
+version: 1.0.3
 
 appVersion: "7.5.0"
 

--- a/charts/unleash-enterprise/templates/httproute.yaml
+++ b/charts/unleash-enterprise/templates/httproute.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "unleash-enterprise.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "unleash-enterprise.labels" . | nindent 4 }}
+    {{- with .Values.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httproute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httproute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/unleash-enterprise/values.yaml
+++ b/charts/unleash-enterprise/values.yaml
@@ -133,6 +133,42 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Gateway API HTTPRoute configuration
+# Ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+httproute:
+  # -- Enable HTTPRoute resource (Gateway API)
+  enabled: false
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Gateway API parentRefs for the HTTPRoute
+  # Must reference an existing Gateway resource
+  parentRefs: []
+    # - name: example-gateway
+    #   namespace: example-gateway-namespace
+    #   sectionName: https
+  # -- List of hostnames for the HTTPRoute
+  hostnames: []
+    # - unleash-enterprise.example.com
+  # -- HTTPRoute rules configuration
+  # Note: backendRefs in custom rules will be ignored;
+  # the chart service is always used as the backend.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # filters: []
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Custom-Header
+      #           value: custom-value
+      # timeouts:
+      #   request: 10s
+      #   backendRequest: 2s
+
 initContainers: []
 extraContainers: []
 

--- a/charts/unleash-proxy/Chart.yaml
+++ b/charts/unleash-proxy/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.11
+version: 0.8.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/unleash-proxy/templates/httproute.yaml
+++ b/charts/unleash-proxy/templates/httproute.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "unleash-proxy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "unleash-proxy.labels" . | nindent 4 }}
+    {{- with .Values.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httproute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httproute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/unleash-proxy/values.yaml
+++ b/charts/unleash-proxy/values.yaml
@@ -80,6 +80,42 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Gateway API HTTPRoute configuration
+# Ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+httproute:
+  # -- Enable HTTPRoute resource (Gateway API)
+  enabled: false
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Gateway API parentRefs for the HTTPRoute
+  # Must reference an existing Gateway resource
+  parentRefs: []
+    # - name: example-gateway
+    #   namespace: example-gateway-namespace
+    #   sectionName: https
+  # -- List of hostnames for the HTTPRoute
+  hostnames: []
+    # - unleash-proxy.example.com
+  # -- HTTPRoute rules configuration
+  # Note: backendRefs in custom rules will be ignored;
+  # the chart service is always used as the backend.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # filters: []
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Custom-Header
+      #           value: custom-value
+      # timeouts:
+      #   request: 10s
+      #   backendRequest: 2s
+
 resources:
   {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/unleash/Chart.yaml
+++ b/charts/unleash/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 5.6.6
+version: 5.6.7
 
 appVersion: "7.5.0"
 

--- a/charts/unleash/templates/httproute.yaml
+++ b/charts/unleash/templates/httproute.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "unleash.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "unleash.labels" . | nindent 4 }}
+    {{- with .Values.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httproute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httproute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/unleash/values.yaml
+++ b/charts/unleash/values.yaml
@@ -137,6 +137,42 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Gateway API HTTPRoute configuration
+# Ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+httproute:
+  # -- Enable HTTPRoute resource (Gateway API)
+  enabled: false
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Gateway API parentRefs for the HTTPRoute
+  # Must reference an existing Gateway resource
+  parentRefs: []
+    # - name: example-gateway
+    #   namespace: example-gateway-namespace
+    #   sectionName: https
+  # -- List of hostnames for the HTTPRoute
+  hostnames: []
+    # - unleash.example.com
+  # -- HTTPRoute rules configuration
+  # Note: backendRefs in custom rules will be ignored;
+  # the chart service is always used as the backend.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # filters: []
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Custom-Header
+      #           value: custom-value
+      # timeouts:
+      #   request: 10s
+      #   backendRequest: 2s
+
 initContainers: []
 extraContainers: []
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Add HTTPRoute support for Gateway API. Gateway API is the successor to Ingress API with improved design and capabilities.
The Ingress-NGINX Controller is deprecated, so user can migrate from Ingress-NGINX to the Gateway API.
<!-- Does it close an issue? Multiple? -->
Closes https://github.com/Unleash/helm-charts/issues/226

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
httproute.yaml and values.yaml in each charts
