### PR TITLE
feat: add init container hook

### DIFF
--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 3.1.5
+version: 3.1.6
 appVersion: "v20.1.10"
 
 maintainers:

--- a/charts/unleash-edge/Chart.yaml
+++ b/charts/unleash-edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://docs.getunleash.io/img/logo.svg
 
 type: application
 
-version: 3.1.6
+version: 3.2.0
 appVersion: "v20.1.10"
 
 maintainers:

--- a/charts/unleash-edge/README.md
+++ b/charts/unleash-edge/README.md
@@ -58,6 +58,8 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 See description of configuration in the values.yaml
 
+Use `initContainers` to add Kubernetes init containers to the Edge pod. This can be combined with `volumes` and `volumeMounts` when an init container needs to prepare files for the main Edge container.
+
 To delay shutdown during pod termination, you can optionally configure a `preStop` hook together with `terminationGracePeriodSeconds`:
 
 ```yaml

--- a/charts/unleash-edge/templates/deployment.yaml
+++ b/charts/unleash-edge/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
       serviceAccountName: {{ include "unleash-edge.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "unleash-edge.name" . }}
           args: {{ .Values.edge.command }}

--- a/charts/unleash-edge/values.yaml
+++ b/charts/unleash-edge/values.yaml
@@ -155,12 +155,6 @@ readinessProbe:
 
 lifecycle:
   {}
-  # preStop:
-  #   exec:
-  #     command:
-  #       - /bin/sh
-  #       - -c
-  #       - sleep 30
 
 autoscaling:
   enabled: false
@@ -180,6 +174,8 @@ topologySpreadConstraints:
   # - maxSkew: 1
   #   topologyKey: topology.kubernetes.io/zone
   #   whenUnsatisfiable: DoNotSchedule
+
+initContainers: []
 
 # Adds environment variables
 env: []


### PR DESCRIPTION
Adds an init container hook so that users can inject their own binaries into the chart if they needed